### PR TITLE
Bug/QoL fixes around the text selection UI

### DIFF
--- a/web/index.css
+++ b/web/index.css
@@ -163,7 +163,9 @@ video, canvas {
   color: white;
 }
 .canvasContextSelectionImage {
-  width: 100%;
+  height: 100%;
+  max-width:100%;
+  max-height:100%;
   display: block;
 }
 .welcome-card-wide.mdl-card {

--- a/web/index.js
+++ b/web/index.js
@@ -429,7 +429,10 @@ function toggleAutoMode() {
   if (autoMode) {
     refreshButton.disabled = true;
     autoModeTimer = setInterval(()=>{
-      if (rect.width > 0 && OCRrequests === 0) {
+      // Updating the OCR scrolls the page down to show it, which becomes
+      // very obnoxious when you're trying to position a box over the right text.
+      // To fix this, we just don't update when we're dragging a selection.
+      if (rect.width > 0 && OCRrequests === 0 && !mousedown) {
         showStuff(rect);
       }
     }, autoModeSpeed);

--- a/web/index.js
+++ b/web/index.js
@@ -311,8 +311,8 @@ function changeOutputText(outputElement) {
 
 cv1.addEventListener("mouseup", function (e) {
   mousedown = false;
-  const isRightClick = e.button === 0;
-  if (hasSelection() && !clipboardMode && isRightClick) {
+  const isLeftClick = e.button === 0;
+  if (hasSelection() && !clipboardMode && isLeftClick) {
     // Invert selection if selection is from  top left
     if (rect.height < 0) {
       rect.y += rect.height;
@@ -338,11 +338,14 @@ cv1.addEventListener("mouseup", function (e) {
 cv1.addEventListener("mousedown", function (e) {
   // find correct position if scrolled down
   // there is no need for scrollXoffset because the video is always resized to 100% the width of the window
-  const scrollYOffset  = window.pageYOffset || document.documentElement.scrollTop;
+  const isLeftClick = e.button === 0;
 
-  last_mousex = parseInt(e.clientX-canvasx);
-	last_mousey = parseInt(e.clientY-canvasy+scrollYOffset);
-  mousedown = true;
+  if (isLeftClick) {
+      const scrollYOffset = window.pageYOffset || document.documentElement.scrollTop;
+      last_mousex = parseInt(e.clientX-canvasx);
+      last_mousey = parseInt(e.clientY-canvasy+scrollYOffset);
+      mousedown = true;
+  }
 }, false);
 
 cv1.addEventListener("mousemove", function (e) {

--- a/web/settings.js
+++ b/web/settings.js
@@ -267,6 +267,7 @@ function updateOCREngine() {
         textOrientationSwitch.disabled = true;
         textOrientationSwitch.parentNode.classList.add("is-disabled");
     }
+    refreshOCR();
     return OCREngine;
 }
 
@@ -282,6 +283,7 @@ function updateOCREngineAndPersist() {
   
 function toggleTextOrientation() {
     verticalText = !verticalText;
+    refreshOCR();
 }
 
 /*


### PR DESCRIPTION
Four small fixes pulled from the Chinese support fork:
- Fix bug where right clicking to open the OCR settings would start updating the current OCR
- Stop the app from scrolling down when you're resizing an auto selection.
- Make OCR settings selection image scale up less.
- Refresh the OCR whenever you change the engine/text orientation.