### PR TITLE
Add ability to capture from webcam video source

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -275,7 +275,22 @@
                       </span>
                     </li>
                   </ul>
-                   
+
+                  <ul class="mdl-list">
+                    <li class="mdl-list__item">
+                      <span class="mdl-list__item-primary-content">
+                        Select New Capture Device
+                      </span>
+                      <div class="select">
+                          <label for="captureSource">Capture source: </label><select id="captureSource"></select>
+                      </div>
+                      <span class="mdl-list__item-secondary-action">
+                        <button onclick="selectCaptureDevice()" class="mdl-button mdl-js-button mdl-button--icon">
+                          <i class="material-icons">keyboard_arrow_right</i>
+                        </button>
+                      </span>
+                    </li>
+                  </ul>
               </div>
 
               <div class="mdl-tabs__panel" id="hotkeys">


### PR DESCRIPTION
This allows for direct video capture from cheap capture cards that
present as webcams to the OS (like mirabox)

I'd like to add this feature since it'll allow game2text to be used to run OCR on games running on real consoles, without needing to first open the capture card in mpv or obs or something like that just to get game2text to select that window.